### PR TITLE
Change target url to get this month's applications

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -5,7 +5,7 @@ require 'mechanize'
 require 'open-uri'
 require 'nokogiri'
 
-url = "http://online.bankstown.nsw.gov.au/Planning/pages/xc.track/SearchApplication.aspx?o=html&d=lastmonth&k=LodgementDate&t=%23396&ss=a"
+url = "http://online.bankstown.nsw.gov.au/Planning/pages/xc.track/SearchApplication.aspx?o=html&d=thismonth&k=LodgementDate&t=%23396&ss=a"
 
 agent = Mechanize.new
 page = agent.get(url)


### PR DESCRIPTION
It was previously set to last month's. This month's includes
the latest applications.

Because the 'last month' url was only updated monthly, this would only get new applications every month. Now it will get them daily.