### PR TITLE
Change platform from early_release to heroku-18 to fix "Failed to download minimal PHP for bootstrapping!" error

### DIFF
--- a/platform
+++ b/platform
@@ -1,1 +1,1 @@
-early_release
+heroku-18


### PR DESCRIPTION
Change the platform from early_release to heroku-18 since heroku-24 (the new early_release) is broken.

Fixes:
* https://github.com/planningalerts-scrapers/issues/issues/1178