### PR TITLE
Point the AGENTS.md stub at a fetchable URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,18 @@
 # AGENTS.md
 
-This is one of the PlanningAlerts scrapers. Org-wide guidance for agents —
-issue tracking, PR conventions, review process, and scraper conventions —
-lives in the issues repo:
+This is one of the PlanningAlerts scrapers. Org-wide guidance for agents, covering
+issue tracking, pull request conventions, the review process and scraper
+conventions, lives in the issues repo. Fetch and read it before doing any work
+here:
 
+    curl -fsSL https://raw.githubusercontent.com/planningalerts-scrapers/issues/master/AGENTS.md
+
+Any equivalent fetch works: a web fetch of that URL, `gh api` if the GitHub CLI is
+installed, or, if the issues repo happens to be checked out alongside this one,
+`../issues/AGENTS.md` is the same file. Do not assume any particular tool is
+present.
+
+Do not rely on a cached or remembered copy. It changes as org conventions evolve.
+
+Rendered for humans:
 https://github.com/planningalerts-scrapers/issues/blob/master/AGENTS.md
-
-Fetch and read that file before doing any work in this repo. Do not rely on a
-cached or remembered copy; it changes as org conventions evolve.


### PR DESCRIPTION
## Description

Switches the stub to the `raw.githubusercontent.com` URL and gives the `curl` command explicitly. The stub previously linked the GitHub blob page, which returns HTML rather than markdown to `curl`, so an agent without an HTML-rendering fetch could not read the org guidance at all. Also notes that `../issues/AGENTS.md` is the same file when the issues repo happens to be checked out alongside this one, which covers the no-network case, and keeps the blob link for humans.

## Motivation and Context

The stub carries no guidance of its own so that agents always read the current version of `planningalerts-scrapers/issues/AGENTS.md`, the single source of truth for org-wide agent guidance. That only works if the stub gives a URL an agent can actually fetch.

Goes with the restructure of that file in planningalerts-scrapers/issues#1442. This is intended to be the last edit the stub ever needs: it names no section and no version, so future guidance changes happen only in the issues repo.

Identical content is being applied to every scraper repo in the org, which is why there are a lot of these.

## How Has This Been Tested?

Documentation change. The raw URL was confirmed to return the file over `curl -fsSL`, and the rendered result was read to check it is the guidance and not an HTML page.

- [x] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

The unticked boxes do not apply: this change touches only markdown and cannot affect the scraper.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
